### PR TITLE
apply physicist conventions: shortfall + cross-class contrast

### DIFF
--- a/src/interpret/occlusion.py
+++ b/src/interpret/occlusion.py
@@ -90,7 +90,12 @@ def _sample_random_windows(
     forbidden_mask: np.ndarray,
 ) -> list[tuple[float, float]]:
     """Draw ``n_segments`` random windows whose total width matches ``total_width_aa``
-    and avoid any bin flagged in ``forbidden_mask``."""
+    and avoid any bin flagged in ``forbidden_mask``.
+
+    All-or-nothing: returns ``[]`` if the full ``n_segments`` cannot be drawn,
+    so a partial sample never enters the null distribution with mismatched
+    geometry (Physicist convention: fail-closed on geometry mismatch).
+    """
     seg_width = total_width_aa / n_segments
     wmin = float(wave_centers.min())
     wmax = float(wave_centers.max())
@@ -103,7 +108,7 @@ def _sample_random_windows(
             picks.append((lo, hi))
             if len(picks) == n_segments:
                 return picks
-    return picks  # best-effort
+    return []
 
 
 def masked_line_ablation(

--- a/tests/test_lines.py
+++ b/tests/test_lines.py
@@ -109,3 +109,84 @@ def test_lines_for_class_k_excludes_balmer():
     assert "H_beta" not in names
     assert {"Mg_b1", "Mg_b2", "Mg_b3"} <= names
     assert {"Na_D1", "Na_D2"} <= names
+
+
+# ---------------------------------------------------------------------------
+# Cross-class contrast assertions.
+#
+# These guard the *physical* contract of the registry: the MK sequence is a
+# temperature ordering A > F > G > K, so diagnostic-line sets must contrast
+# across classes in physically expected directions (Gray & Corbally 2009;
+# Gray 2005). If a future edit silently equates two classes' diagnostic
+# vocabularies, the ablation/SHAP audit becomes meaningless and these tests
+# fail loudly.
+# ---------------------------------------------------------------------------
+
+
+def test_every_class_has_at_least_one_diagnostic_line():
+    for mk_class in ALLOWED_MK_CLASSES:
+        assert lines_for_class(mk_class), (
+            f"class {mk_class!r} has no diagnostic lines in MK_LINES - "
+            "ablation and per-class SHAP would be undefined"
+        )
+
+
+def test_a_and_k_diagnostic_sets_are_disjoint():
+    # A is hottest in the AFGK set (Balmer-dominated); K is coolest
+    # (metal-line dominated). They must share no diagnostic line, otherwise
+    # the registry cannot resolve the two ends of the temperature axis.
+    a_names = {line.name for line in lines_for_class("A")}
+    k_names = {line.name for line in lines_for_class("K")}
+    assert a_names.isdisjoint(k_names), (
+        f"A and K share diagnostic lines {a_names & k_names!r} - "
+        "Balmer-vs-metal contrast is broken"
+    )
+
+
+def test_f_is_transitional_between_a_and_g():
+    # F sits between A (Balmer-strong) and G (Mg b-strong); its diagnostic
+    # set must overlap both neighbours, otherwise F has no place on the
+    # temperature ordering.
+    f_names = {line.name for line in lines_for_class("F")}
+    a_names = {line.name for line in lines_for_class("A")}
+    g_names = {line.name for line in lines_for_class("G")}
+    assert f_names & a_names, "F shares no Balmer line with A"
+    assert f_names & g_names, "F shares no metal line with G"
+
+
+def test_k_has_more_metal_lines_than_a():
+    # Cool stars show many more metal lines than hot ones; the registry's
+    # diagnostic counts must reflect that ordering.
+    n_a = len(lines_for_class("A"))
+    n_k = len(lines_for_class("K"))
+    assert n_k > n_a, (
+        f"K ({n_k} lines) does not dominate A ({n_a} lines) in metal-line "
+        "diagnostics - registry is unphysical"
+    )
+
+
+def test_no_balmer_line_diagnoses_cool_classes():
+    # H Balmer lines weaken monotonically below ~7500 K; they cannot be
+    # diagnostic of G or K under the AFGK label set.
+    for line in MK_LINES:
+        if line.species == "HI":
+            assert "G" not in line.diag_for, (
+                f"{line.name} (HI) marked diagnostic for G - violates "
+                "Balmer-weakens-with-cooling"
+            )
+            assert "K" not in line.diag_for, (
+                f"{line.name} (HI) marked diagnostic for K - violates "
+                "Balmer-weakens-with-cooling"
+            )
+
+
+def test_class_pair_g_k_share_metal_lines_but_a_separates():
+    # G and K are intentionally indistinguishable at the line-PRESENCE level
+    # (they differ via line-strength ratios and continuum slope, not via
+    # which lines are diagnostic). What MUST hold is that A is separable
+    # from both: A's set must differ from G's and from K's.
+    a = {line.name for line in lines_for_class("A")}
+    g = {line.name for line in lines_for_class("G")}
+    k = {line.name for line in lines_for_class("K")}
+    assert a != g, "A and G have identical diagnostic-line sets"
+    assert a != k, "A and K have identical diagnostic-line sets"


### PR DESCRIPTION
- occlusion._sample_random_windows: return [] on shortfall instead of
  a partial pick list, so the random-window null distribution never
  enters with mismatched geometry (fail-closed).
- tests/test_lines.py: add 6 cross-class contrast assertions (A/K
  diagnostic disjointness, F transitional bridging, K dominates A in
  metal-line counts, no Balmer for cool classes, A separability from
  G and K, every class non-empty).

https://claude.ai/code/session_01S3AU5UiVpFdhMQrDVASTWQ